### PR TITLE
fix: declare @babel/runtime as a runtime dependency

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -24,6 +24,9 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },
+  "dependencies": {
+    "@babel/runtime": "^7.0.0"
+  },
   "devDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
# PR Title
fix(core): declare `@babel/runtime` as a runtime dependency

# PR Description
## Summary
`@uiw/react-split` publishes `cjs/index.js` and `esm/index.js` files that import Babel runtime helpers (for example `@babel/runtime/helpers/interopRequireDefault` and `@babel/runtime/helpers/extends`) but the package manifest does not currently declare `@babel/runtime`.

That makes installs non-deterministic:
- Works when `@babel/runtime` happens to be hoisted by other deps.
- Fails in stricter dependency resolution setups (for example pnpm + modern Next.js bundling) with module resolution errors.

This PR adds the missing runtime dependency directly to `core/package.json`.

## Root Cause
Published artifacts require `@babel/runtime`, but `core/package.json` only declares `peerDependencies` (`react`, `react-dom`) and `devDependencies`, not the runtime dependency used by shipped JS.

## Changes
- Added:
  - `"dependencies": { "@babel/runtime": "^7.0.0" }`

## Why this is safe
- No source/runtime logic changes.
- No API changes.
- Only package metadata is corrected so consumers reliably receive required runtime helpers.

## Validation
- Confirmed published package imports runtime helpers from npm tarball (`@uiw/react-split@5.9.3`).
- Confirmed manifest now includes `@babel/runtime` in `dependencies`.
- Ran `pnpm --dir core pack` successfully after the change.

## Reviewer Notes
If you want to verify quickly:
1. Inspect current npm tarball and note `@babel/runtime` imports in `cjs/index.js` / `esm/index.js`.
2. Confirm this PR adds `@babel/runtime` to package dependencies.

# Suggested Images to Attach
1. **Error screenshot (Before):** app/build error showing `Can't resolve '@babel/runtime/helpers/...` when importing `@uiw/react-split`.
2. **Diff screenshot:** `core/package.json` showing only the `dependencies.@babel/runtime` addition.
3. **Success screenshot (After):** same app compiling/running successfully with split panes visible.
4. **Optional evidence screenshot:** terminal output from tarball inspection showing helper imports in published `cjs/index.js` / `esm/index.js`.
