### PR TITLE
fix: add missing @babel/runtime dependency

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -24,6 +24,9 @@
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0"
   },
+  "dependencies": {
+    "@babel/runtime": "^7.0.0"
+  },
   "devDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
# Description
The published `cjs/index.js` and `esm/index.js` files import from `@babel/runtime` (e.g. `interopRequireDefault`, `extends`), but it's missing from `dependencies` in `core/package.json`. This means installs only work when `@babel/runtime` happens to be hoisted by something else - and break in stricter setups like pnpm or modern Next.js bundling.

This PR adds `"@babel/runtime": "^7.0.0"` to `dependencies`. No code changes, just a metadata fix.

## Validation
- Inspected the published npm tarball (`@uiw/react-split@5.9.3`) and confirmed the runtime imports.
- Ran `pnpm --dir core pack` successfully after the change.

# Before: @uiw/react-split fails due to missing @babel/runtime dependency
<img width="1267" height="458" alt="Screenshot 2026-02-09 at 6 14 09 PM" src="https://github.com/user-attachments/assets/39cf4a1f-2b72-409b-aabf-19ebfd64d7dc" />

